### PR TITLE
MQTT Client Username

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,5 @@
 /samples/ttnmgmt/target/
 /samples/samples-management/target/
 /samples/samples-amqp/target/
+/.idea/
+*.iml

--- a/data/data-mqtt/src/main/java/org/thethingsnetwork/data/mqtt/Client.java
+++ b/data/data-mqtt/src/main/java/org/thethingsnetwork/data/mqtt/Client.java
@@ -116,6 +116,9 @@ public class Client extends AbstractClient {
         }
         connOpts.setUserName(_appId);
         connOpts.setPassword(_appAccessKey.toCharArray());
+        if (_connOpts.getUserName() != null) {
+            connOpts.setUserName(_connOpts.getUserName());
+        }
     }
 
     private String validateBroker(String _source) throws URISyntaxException {


### PR DESCRIPTION
Added the possibility to set a different username than the appId using MqttConnectOptions in the MQTT client constructor
Gitignore modified for IntelliJ